### PR TITLE
service: support data validation

### DIFF
--- a/invenio_records_resources/resources/record.py
+++ b/invenio_records_resources/resources/record.py
@@ -51,8 +51,7 @@ class RecordResource(CollectionResource):
     #
     def search(self, *args, **kwargs):
         """Perform a search over the items."""
-        # TODO fix identity extraction
-        identity = g.identiy
+        identity = g.identity
         record_search = self.service_cls.search(
             querystring=resource_requestctx.request_args.get("q", ""),
             identity=identity,

--- a/invenio_records_resources/schemas/__init__.py
+++ b/invenio_records_resources/schemas/__init__.py
@@ -8,10 +8,10 @@
 
 """Marshmallow schemas for serialization."""
 
-from .json import Nested, RecordMetadataSchemaJSONV1, RecordSchemaJSONV1
+from .json import MetadataSchemaJSONV1, Nested, RecordSchemaJSONV1
 
 __all__ = (
+    "MetadataSchemaJSONV1",
     "RecordSchemaJSONV1",
     "Nested",
-    "RecordMetadataSchemaJSONV1",
 )

--- a/invenio_records_resources/schemas/fields/__init__.py
+++ b/invenio_records_resources/schemas/fields/__init__.py
@@ -8,5 +8,6 @@
 """Custom marshmallow fields."""
 
 from .persistent_identifier import PersistentIdentifier
+from .sanitized_unicode import SanitizedUnicode
 
-__all__ = ("PersistentIdentifier",)
+__all__ = ("PersistentIdentifier", "SanitizedUnicode")

--- a/invenio_records_resources/schemas/fields/sanitized_unicode.py
+++ b/invenio_records_resources/schemas/fields/sanitized_unicode.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+#
+# Invenio-Records-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Sanitized Unicode string field."""
+
+from ftfy import fix_text
+from marshmallow import fields
+
+
+class TrimmedString(fields.String):
+    """String field which strips whitespace the ends of the string."""
+
+    def _deserialize(self, value, attr, data, **kwargs):
+        """Deserialize string value."""
+        value = super(TrimmedString, self)._deserialize(
+            value, attr, data, **kwargs)
+        return value.strip()
+
+
+class SanitizedUnicode(TrimmedString):
+    """String field that sanitizes and fixes problematic unicode characters."""
+
+    UNWANTED_CHARACTERS = {
+        # Zero-width space
+        u'\u200b',
+    }
+
+    def is_valid_xml_char(self, char):
+        """Check if a character is valid based on the XML specification."""
+        codepoint = ord(char)
+        return (0x20 <= codepoint <= 0xD7FF or
+                codepoint in (0x9, 0xA, 0xD) or
+                0xE000 <= codepoint <= 0xFFFD or
+                0x10000 <= codepoint <= 0x10FFFF)
+
+    def _deserialize(self, value, attr, data, **kwargs):
+        """Deserialize sanitized string value."""
+        value = super(SanitizedUnicode, self)._deserialize(
+            value, attr, data, **kwargs)
+        value = fix_text(value)
+
+        # NOTE: This `join` might be ineffiecient... There's a solution with a
+        # large compiled regex lying around, but needs a lot of tweaking.
+        value = ''.join(filter(self.is_valid_xml_char, value))
+        for char in self.UNWANTED_CHARACTERS:
+            value = value.replace(char, '')
+        return value

--- a/invenio_records_resources/service/__init__.py
+++ b/invenio_records_resources/service/__init__.py
@@ -8,9 +8,12 @@
 
 """High-level API for wokring with records, files, pids and search."""
 
+from .data_validator import DataValidator, MarshmallowDataValidator
 from .service import RecordService, RecordServiceConfig
 
 __all__ = (
-    'RecordService',
-    'RecordServiceConfig',
+    "DataValidator",
+    "MarshmallowDataValidator",
+    "RecordService",
+    "RecordServiceConfig",
 )

--- a/invenio_records_resources/service/data_validator.py
+++ b/invenio_records_resources/service/data_validator.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+#
+# Invenio-Records-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Data validation API."""
+
+from ..schemas import MetadataSchemaJSONV1
+
+
+class DataValidator:
+    """Data validator interface."""
+
+    def validate(self, data, *args, **kwargs):
+        """Validate data."""
+        raise NotImplementedError()
+
+
+class MarshmallowDataValidator:
+    """Data validator based on a Marshamllow schema."""
+
+    def __init__(self, schema=MetadataSchemaJSONV1, *args, **kwargs):
+        """Constructor."""
+        self.schema = schema
+
+    def validate(self, data, context=None):
+        """Validate by dumping it on the marshmallow schema.
+
+        :returns: The validated data as a dict.
+        """
+        return self.schema(context=context).load(data)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,35 +37,16 @@ def create_app(instance_path):
     return _create_api
 
 
-# FIXME: this two should come from `invenio-rdm-records`
-# However, this module should not be RDM dependent
 @pytest.fixture(scope="function")
-def minimal_input_record():
+def input_record():
     """Minimal record data as dict coming from the external world."""
     return {
         "_access": {"metadata_restricted": False, "files_restricted": False},
         "_owners": [1],
         "_created_by": 1,
-        "access_right": "open",
-        "resource_type": {"type": "image", "subtype": "image-photo"},
-        # Technically not required
-        "creators": [],
-        "titles": [
-            {"title": "A Romans story", "type": "Other", "lang": "eng"}
-        ],
+        "title": "A Romans story",
+        "description": "A looong description full of lorem ipsums"
     }
-
-
-@pytest.fixture(scope="function")
-def minimal_record(minimal_input_record):
-    """Dictionary with the minimum required fields to create a record.
-
-    It fills in the missing and post_loaded fields.
-    """
-    record = deepcopy(minimal_input_record)
-    record["publication_date"] = date.today().isoformat()
-    record["_publication_date_search"] = date.today().isoformat()
-    return record
 
 
 @pytest.fixture()

--- a/tests/service/test_data_validator.py
+++ b/tests/service/test_data_validator.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+#
+# Invenio-Records-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Data validator tests."""
+
+import pytest
+from marshmallow import Schema, fields
+from marshmallow.exceptions import ValidationError
+
+from invenio_records_resources.service import DataValidator, \
+    MarshmallowDataValidator
+
+
+def test_data_validator():
+    """Tests the data validator interface."""
+
+    validator = DataValidator()
+
+    with pytest.raises(NotImplementedError):
+        validator.validate(data=None)
+
+
+def test_marshmallow_data_validator(input_record):
+    """Tests the marshmallow data validator."""
+
+    validator = MarshmallowDataValidator()
+    validated_data = validator.validate(data=input_record)
+
+    fields_to_check = input_record.keys()
+    validated_data_keys = validated_data.keys()
+    for field in fields_to_check:
+        assert field in validated_data
+
+    assert len(fields_to_check) == len(validated_data_keys)
+
+
+def test_marshmallow_data_validator_fail(input_record):
+    """Tests the marshmallow data validator with invalid data."""
+
+    validator = MarshmallowDataValidator()
+    input_record.pop("title")
+
+    with pytest.raises(ValidationError) as validation_error:
+        invalidated_data = validator.validate(data=input_record)
+
+    error_message = validation_error.value.messages
+
+    assert "title" in error_message.keys()
+
+
+class CustomSchemaJSONV1(Schema):
+    """Custom schema class."""
+
+    custom_field = fields.String()
+
+
+def test_marshmallow_data_validator_with_custom_schema():
+    """Tests the marshmallow data validator."""
+
+    input_record = {"custom_field": "test_value"}
+
+    validator = MarshmallowDataValidator(schema=CustomSchemaJSONV1)
+    validated_data = validator.validate(data=input_record)
+
+    assert "custom_field" in validated_data
+
+
+def test_marshmallow_data_validator_with_custom_schema_fail(input_record):
+    """Tests the marshmallow data validator with invalid data."""
+
+    input_record = {
+        "custom_field": "test_value",
+        "non_desired_field": "test_value"
+    }
+
+    validator = MarshmallowDataValidator(schema=CustomSchemaJSONV1)
+
+    with pytest.raises(ValidationError) as validation_error:
+        invalidated_data = validator.validate(data=input_record)
+
+    error_message = validation_error.value.messages
+
+    assert "non_desired_field" in error_message.keys()

--- a/tests/test_record_resource.py
+++ b/tests/test_record_resource.py
@@ -19,11 +19,11 @@ from invenio_records_resources.service.errors import PermissionDeniedError
 HEADERS = {"content-type": "application/json", "accept": "application/json"}
 
 
-def test_create_read_record(client, minimal_record):
+def test_create_read_record(client, input_record):
     """Test record creation."""
     # Create new record
     response = client.post(
-        "/records_v2", headers=HEADERS, data=json.dumps(minimal_record)
+        "/records_v2", headers=HEADERS, data=json.dumps(input_record)
     )
     assert response.status_code == 200
     response_fields = response.json.keys()
@@ -47,41 +47,40 @@ def test_create_read_record(client, minimal_record):
         assert field in response_fields
 
 
-# TODO: Fix and uncomment
-# def test_create_search_record(client, minimal_record):
-#     """Test record search."""
-#     # Search records, should return empty
-#     # response = client.get("/records_v2", headers=HEADERS)
-#     # assert response.status_code == 200
+def test_create_search_record(client, input_record):
+    """Test record search."""
+    # Search records, should return empty
+    response = client.get("/records_v2", headers=HEADERS)
+    assert response.status_code == 200
 
-#     # Create dummy record to test search
-#     response = client.post(
-#         "/records_v2", headers=HEADERS, data=json.dumps(minimal_record)
-#     )
-#     assert response.status_code == 200
-#     print("response.json", response.json)
+    # Create dummy record to test search
+    response = client.post(
+        "/records_v2", headers=HEADERS, data=json.dumps(input_record)
+    )
+    assert response.status_code == 200
+    print("response.json", response.json)
 
-#     # Search content of record, should return the record
-#     response = client.get("/records_v2?q=story", headers=HEADERS)
-#     assert response.status_code == 200
+    # Search content of record, should return the record
+    response = client.get("/records_v2?q=story", headers=HEADERS)
+    assert response.status_code == 200
 
-#     # Search for something non-existent, should return empty
-#     response = client.get("/records_v2?q=notfound", headers=HEADERS)
-#     assert response.status_code == 200
+    # Search for something non-existent, should return empty
+    response = client.get("/records_v2?q=notfound", headers=HEADERS)
+    assert response.status_code == 200
 
 
-def test_create_delete_record(client, minimal_record):
+def test_create_delete_record(client, input_record):
     """Test record deletion."""
     # Create dummy record to test delete
     response = client.post(
-        "/records_v2", headers=HEADERS, data=json.dumps(minimal_record)
+        "/records_v2", headers=HEADERS, data=json.dumps(input_record)
     )
     assert response.status_code == 200
     recid = response.json["pid"]
 
     # Update the record
-    updated_record = minimal_record
-    updated_record["titles"][0]["title"] = "updated title"
+    updated_record = input_record
+    updated_record["title"] = "updated title"
     response = client.put("/records_v2/{}".format(recid), headers=HEADERS,
                           data=json.dumps(updated_record))
     assert response.status_code == 200
@@ -92,37 +91,37 @@ def test_create_delete_record(client, minimal_record):
     assert response.status_code == 204
 
 
-def test_create_update_record(client, minimal_record):
+def test_create_update_record(client, input_record):
     """Test record update."""
     # Create dummy record to test update
     response = client.post(
-        "/records_v2", headers=HEADERS, data=json.dumps(minimal_record)
+        "/records_v2", headers=HEADERS, data=json.dumps(input_record)
     )
     assert response.status_code == 200
     recid = response.json["pid"]
 
     # Update the record
     new_title = "updated title"
-    minimal_record["titles"][0]["title"] = new_title
+    input_record["title"] = new_title
     response = client.put("/records_v2/{}".format(recid), headers=HEADERS,
-                          data=json.dumps(minimal_record))
+                          data=json.dumps(input_record))
     assert response.status_code == 200
 
     # Read the record
     response = client.get("/records_v2/{}".format(recid), headers=HEADERS)
     assert response.status_code == 200
-    assert response.json["metadata"]["titles"][0]["title"] == new_title
+    assert response.json["metadata"]["title"] == new_title
 
 
 def test_create_record_permissions(app_with_custom_permissions, client,
-                                   minimal_record, users):
+                                   input_record, users):
     """Test record creation."""
     user1 = users['user1']
     user2 = users['user2']
     # Create new record as anonymous
     with pytest.raises(PermissionDeniedError) as e:
         response = client.post(
-            "/records_v2", headers=HEADERS, data=json.dumps(minimal_record)
+            "/records_v2", headers=HEADERS, data=json.dumps(input_record)
         )
 
     # Create new record as user with no `admin-access`
@@ -132,7 +131,7 @@ def test_create_record_permissions(app_with_custom_permissions, client,
 
     with pytest.raises(PermissionDeniedError) as e:
         response = client.post(
-            "/records_v2", headers=HEADERS, data=json.dumps(minimal_record)
+            "/records_v2", headers=HEADERS, data=json.dumps(input_record)
         )
 
     # logout user2
@@ -143,7 +142,7 @@ def test_create_record_permissions(app_with_custom_permissions, client,
     login_user_via_view(client, email=user1['email'],
                         password=user1['password'], login_url='/login')
     response = client.post(
-        "/records_v2", headers=HEADERS, data=json.dumps(minimal_record)
+        "/records_v2", headers=HEADERS, data=json.dumps(input_record)
     )
     assert response.status_code == 200
     response_fields = response.json.keys()
@@ -151,3 +150,15 @@ def test_create_record_permissions(app_with_custom_permissions, client,
                        'created', 'updated', 'links']
     for field in fields_to_check:
         assert field in response_fields
+
+
+# # FIXME: Currently throws exception. Error handling needed
+# def test_create_invalid_record(client, input_record):
+#     """Test invalid record creation."""
+#     input_record.pop("title")  # Remove a required field of the record
+
+#     response = client.post(
+#         "/records_v2", headers=HEADERS, data=json.dumps(input_record)
+#     )
+
+#     # TODO: Assert


### PR DESCRIPTION
- Support using marshmallow schemas
- Refactor current schemas to support a non RDM tight metadata schema
- Refactor tests to reflect the new schemas
- Tests:
    - Test data validator interface (for coverage reasons only)
    - Tests default marshmallow data validator
    - Test  marshmallow data validator with custom schema
    - Test request with validation error commented out, because it throws an exception. Error handling will solve this issue.

Careful if https://github.com/inveniosoftware/invenio-resources/pull/24 is merged before. It implies a rebase and refactor on the tests structure.